### PR TITLE
Deleted 'manage users'  :fire:

### DIFF
--- a/views/overview.ejs
+++ b/views/overview.ejs
@@ -14,10 +14,6 @@
             <button type="submit" form="filter"  class="filter-button-close hide-filter">Done</button>
            <% } %>
         </li>
-
-        <li>
-        <a href="/profile" class="butt">Manage Users</a>
-        </li>
         </ul>
     </nav>
     </div>


### PR DESCRIPTION
I removed the manage users tab from the navigation section on the overview page. The link was made for testing purposes only. Not intended for the end user.